### PR TITLE
Update version to 1.1.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "access" %}
-{% set version = "1.1.10.post3" %}
+{% set version = "1.1.10" %}
 
 package:
   name: {{ name }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://github.com/pysal/access/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7f4ed30a20b4db702d14d46e3adb0677f600823e104207bd4d181731018dab79
+  sha256: d34bf16dec72edce286ba3c646a747d55ed664f8ad9eb095551c0dbc7122f3bf
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  # The latest geopandas version supports Python 3.13
-  skip: true  # [py<311 or py>313]
+  skip: true  # [py<311]
 
 requirements:
   host:


### PR DESCRIPTION
access 1.1.10

**Destination channel:** defaults

### Links

- [PKG-13188](https://anaconda.atlassian.net/browse/PKG-13188) 
- [Upstream repository](https://github.com/pysal/access)

### Explanation of changes:
- New version number
- Supporting build with python 3.14


[PKG-13188]: https://anaconda.atlassian.net/browse/PKG-13188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ